### PR TITLE
Make mounting suppressible during device creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:wily
+
+COPY loopback /opt/loopback

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM ubuntu:wily
 
 COPY loopback /opt/loopback
+
+ENTRYPOINT ["/opt/loopback"]

--- a/create.go
+++ b/create.go
@@ -25,6 +25,7 @@ Images are created in /var/lib/loopback. Then attached to a loopback, formatted 
 		imagePath string
 		size      int
 		fs        string
+		noMount   bool
 	}
 )
 
@@ -33,6 +34,7 @@ func init() {
 	createCmd.Flags().StringVar(&createFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
 	createCmd.Flags().IntVar(&createFlags.size, "size", 1, "Size of the volume (in gigabytes)")
 	createCmd.Flags().StringVar(&createFlags.fs, "fs", "btrfs", "Filesystem")
+	createCmd.Flags().BoolVar(&createFlags.noMount, "no-mount", false, "Do not mount the created loopback device")
 }
 
 func createRun(cmd *cobra.Command, args []string) {
@@ -68,10 +70,12 @@ func createRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	loop.Mount(device, mountPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Couldn't mount loopback: %s\n", err)
-		os.Exit(1)
+	if createFlags.noMount == false {
+		loop.Mount(device, mountPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't mount loopback: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	os.Exit(0)

--- a/create.go
+++ b/create.go
@@ -25,7 +25,7 @@ Images are created in /var/lib/loopback. Then attached to a loopback, formatted 
 		imagePath string
 		size      int
 		fs        string
-		noMount   bool
+		mountPath string
 	}
 )
 
@@ -34,21 +34,18 @@ func init() {
 	createCmd.Flags().StringVar(&createFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
 	createCmd.Flags().IntVar(&createFlags.size, "size", 1, "Size of the volume (in gigabytes)")
 	createCmd.Flags().StringVar(&createFlags.fs, "fs", "btrfs", "Filesystem")
-	createCmd.Flags().BoolVar(&createFlags.noMount, "no-mount", false, "Do not mount the created loopback device")
+	createCmd.Flags().StringVar(&createFlags.mountPath, "mount-path", "", "Path to mount loopback device into")
 }
 
 func createRun(cmd *cobra.Command, args []string) {
-	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "Mount path parameter missing.")
-		os.Exit(1)
-	}
+	var err error
 
-	mountPath := args[0]
-
-	_, err := os.Stat(mountPath)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Mount path does not exist.")
-		os.Exit(1)
+	if createFlags.mountPath != "" {
+		_, err := os.Stat(createFlags.mountPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Mount path does not exist.")
+			os.Exit(1)
+		}
 	}
 
 	err = image.Create(createFlags.name, createFlags.imagePath, createFlags.size)
@@ -70,8 +67,8 @@ func createRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	if createFlags.noMount == false {
-		loop.Mount(device, mountPath)
+	if createFlags.mountPath != "" {
+		loop.Mount(device, createFlags.mountPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't mount loopback: %s\n", err)
 			os.Exit(1)

--- a/mount.go
+++ b/mount.go
@@ -22,23 +22,23 @@ Attach an image as a loopback and then mount it.
 	mountFlags struct {
 		name      string
 		imagePath string
+		mountPath string
 	}
 )
 
 func init() {
 	mountCmd.Flags().StringVar(&mountFlags.name, "name", "", "Name of the volume")
 	mountCmd.Flags().StringVar(&mountFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
+	mountCmd.Flags().StringVar(&createFlags.mountPath, "mount-path", "", "Path to mount loopback device into")
 }
 
 func mountRun(cmd *cobra.Command, args []string) {
-	if len(args) < 1 {
+	if mountFlags.mountPath == "" {
 		fmt.Fprintln(os.Stderr, "Mount path parameter missing.")
 		os.Exit(1)
 	}
 
-	mountPath := args[0]
-
-	_, err := os.Stat(mountPath)
+	_, err := os.Stat(mountFlags.mountPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Mount path does not exist.")
 		os.Exit(1)
@@ -51,7 +51,7 @@ func mountRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	loop.Mount(device, mountPath)
+	loop.Mount(device, mountFlags.mountPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't mount loopback: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This will add the `--no-mount` flag to the `create` command to make automatic mounting of devices during creation suppressible.
