### PR TITLE
Extend image workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 PROJECT=loopback
 ORGANIZATION=teemow
 
-SOURCE := $(shell find . -name '*.go')
-VERSION := $(shell cat VERSION)
-PROJECT_PATH := $(GOPATH)/src/github.com/$(ORGANIZATION)
-
 GOPATH := $(shell pwd)/.gobuild
 GOVERSION := 1.6.0
 
@@ -15,6 +11,10 @@ ifndef GOARCH
 	GOARCH := amd64
 endif
 
+SOURCE := $(shell find . -name '*.go')
+VERSION := $(shell cat VERSION)
+PROJECT_PATH := $(GOPATH)/src/github.com/$(ORGANIZATION)
+
 .PHONY: all clean run-tests deps bin install
 
 all: deps $(PROJECT)
@@ -23,6 +23,7 @@ ci: clean all run-tests
 
 clean:
 	rm -rf $(GOPATH) $(PROJECT)
+	rm $(PROJECT)
 
 run-tests: 
 	GOPATH=$(GOPATH) go test ./...

--- a/README.md
+++ b/README.md
@@ -31,11 +31,53 @@ make && sudo make install
 
 ## Usage
 
+You can create a mounted loopback device with 15G size like this:
+```
+loopback create --fs=ext4 --name=loopback-test size=15
+```
+
+Whenever you are done with working in the device you can unmount it like this:
+```
+loopback umount --name=loopback-test
+```
+
+When you don't need the device and image anymore you can destroy it like this:
+```
+loopback destroy --name=loopback-test
+```
+
+### Using with Docker containers
+
+You can also use loopback in Docker containers:
+```
+docker run \
+    --rm \
+    -it \
+    --privileged \
+    -v /:/host:shared \
+    teemow/loopback \
+    create --fs=ext4 --image-path=/host/var/lib/loopback --name=loopback-test
+```
+
+If you are not yet using Docker 1.10 you can use `nsenter` which is shipped with
+the image:
+```
+docker run \
+    --rm \
+    -it \
+    --privileged \
+    -v /:/host \
+    --entrypoint=/bin/bash \
+    teemow/loopback \
+    -c "/opt/loopback attach --fs=ext4 --image-path=/host/var/lib/loopback --name=loopback-test --create-missing-image && /opt/loopback list --no-headings | grep loopback-test.img | awk '{print \$1}' | xargs -I{} nsenter --mount=/host/proc/1/ns/mnt -- mount {} /mnt"
+```
+
 ## Dependencies
 
  * `dd`
  * `losetup`
  * `mkfs` (eg for btrfs)
+ * `mount`
 
 Create a btrfs fs for machined
 

--- a/attach.go
+++ b/attach.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/teemow/loopback/image"
+	"github.com/teemow/loopback/loop"
+)
+
+var (
+	attachCmd = &cobra.Command{
+		Use:   "attach",
+		Short: "Attach a loopback device",
+		Long: `Attach a loopback device.
+
+Attach an image as a loopback.
+`,
+		Run: attachRun,
+	}
+
+	attachFlags struct {
+		name               string
+		imagePath          string
+		size               int
+		fs                 string
+		createMissingImage bool
+	}
+)
+
+func init() {
+	attachCmd.Flags().StringVar(&attachFlags.name, "name", "", "Name of the volume")
+	attachCmd.Flags().StringVar(&attachFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
+	attachCmd.Flags().IntVar(&attachFlags.size, "size", 1, "Size of the volume (in gigabytes)")
+	attachCmd.Flags().StringVar(&attachFlags.fs, "fs", "btrfs", "Filesystem")
+	attachCmd.Flags().BoolVar(&attachFlags.createMissingImage, "create-missing-image", false, "Creating image if it does not exist")
+}
+
+func attachRun(cmd *cobra.Command, args []string) {
+	var err error
+
+	if attachFlags.name == "" {
+		fmt.Fprintln(os.Stderr, "Image name parameter missing.")
+		os.Exit(1)
+	}
+
+	createAndFormatImage := false
+	if !image.Exists(attachFlags.name, attachFlags.imagePath) || !attachFlags.createMissingImage {
+		createAndFormatImage = true
+	}
+
+	if createAndFormatImage {
+		err = image.Create(attachFlags.name, attachFlags.imagePath, attachFlags.size)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't create image: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	var device string
+	device, err = loop.Create(attachFlags.name, attachFlags.imagePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't attach loopback: %s\n", err)
+		os.Exit(1)
+	}
+
+	if createAndFormatImage {
+		loop.Format(device, attachFlags.fs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't format loopback: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	os.Exit(0)
+}

--- a/attach.go
+++ b/attach.go
@@ -59,7 +59,7 @@ func attachRun(cmd *cobra.Command, args []string) {
 	}
 
 	var device string
-	device, err = loop.Create(attachFlags.name, attachFlags.imagePath)
+	device, err = loop.Attach(attachFlags.name, attachFlags.imagePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't attach loopback: %s\n", err)
 		os.Exit(1)

--- a/create.go
+++ b/create.go
@@ -38,7 +38,10 @@ func init() {
 }
 
 func createRun(cmd *cobra.Command, args []string) {
-	var err error
+	if createFlags.name == "" {
+		fmt.Fprintln(os.Stderr, "Image name parameter missing.")
+		os.Exit(1)
+	}
 
 	if createFlags.mountPath != "" {
 		_, err := os.Stat(createFlags.mountPath)
@@ -48,7 +51,7 @@ func createRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	err = image.Create(createFlags.name, createFlags.imagePath, createFlags.size)
+	err := image.Create(createFlags.name, createFlags.imagePath, createFlags.size)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create image: %s\n", err)
 		os.Exit(1)

--- a/create.go
+++ b/create.go
@@ -58,7 +58,7 @@ func createRun(cmd *cobra.Command, args []string) {
 	}
 
 	var device string
-	device, err = loop.Create(createFlags.name, createFlags.imagePath)
+	device, err = loop.Attach(createFlags.name, createFlags.imagePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create loopback: %s\n", err)
 		os.Exit(1)

--- a/destroy.go
+++ b/destroy.go
@@ -49,7 +49,7 @@ func destroyRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = loop.Destroy(device)
+	err = loop.Detach(device)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't destroy loopback: %s\n", err)
 		os.Exit(1)

--- a/destroy.go
+++ b/destroy.go
@@ -32,6 +32,11 @@ func init() {
 }
 
 func destroyRun(cmd *cobra.Command, args []string) {
+	if destroyFlags.name == "" {
+		fmt.Fprintln(os.Stderr, "Image name parameter missing.")
+		os.Exit(1)
+	}
+
 	device, err := loop.Find(destroyFlags.name, destroyFlags.imagePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't find loopback: %s\n", err)

--- a/detach.go
+++ b/detach.go
@@ -42,7 +42,7 @@ func detachRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = loop.Destroy(device)
+	err = loop.Detach(device)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't destroy loopback: %s\n", err)
 		os.Exit(1)

--- a/detach.go
+++ b/detach.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/teemow/loopback/loop"
+)
+
+var (
+	detachCmd = &cobra.Command{
+		Use:   "detach",
+		Short: "Detach a loopback device",
+		Long: `Detach a loopback device.
+
+Loopback is deattached.
+`,
+		Run: detachRun,
+	}
+
+	detachFlags struct {
+		name      string
+		imagePath string
+	}
+)
+
+func init() {
+	detachCmd.Flags().StringVar(&detachFlags.name, "name", "", "Name of the volume")
+	detachCmd.Flags().StringVar(&detachFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
+}
+
+func detachRun(cmd *cobra.Command, args []string) {
+	if detachFlags.name == "" {
+		fmt.Fprintln(os.Stderr, "Image name parameter missing.")
+		os.Exit(1)
+	}
+
+	device, err := loop.Find(detachFlags.name, detachFlags.imagePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't find loopback: %s\n", err)
+		os.Exit(1)
+	}
+
+	err = loop.Destroy(device)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't destroy loopback: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/image/image.go
+++ b/image/image.go
@@ -17,11 +17,8 @@ func Create(name, path string, gigaBytes int) error {
 		}
 	}
 
-	imagePath := fmt.Sprintf("%s/%s.img", path, name)
-
-	_, err = os.Stat(imagePath)
-	if err == nil {
-		return fmt.Errorf("image already exists: %s", imagePath)
+	if Exists(name, path) {
+		return fmt.Errorf("image already exists: %s", imagePath(name, path))
 	}
 
 	var dd string
@@ -32,7 +29,7 @@ func Create(name, path string, gigaBytes int) error {
 
 	args := []string{
 		"if=/dev/zero",
-		fmt.Sprintf("of=%s", imagePath),
+		fmt.Sprintf("of=%s", imagePath(name, path)),
 		"bs=1M",
 		fmt.Sprintf("count=%d", gigaBytes*1024),
 	}
@@ -61,12 +58,21 @@ func List(path string) ([]string, error) {
 }
 
 func Destroy(name, path string) error {
-	imagePath := fmt.Sprintf("%s/%s.img", path, name)
-
-	_, err := os.Stat(imagePath)
-	if err != nil {
-		return fmt.Errorf("image doesn't exist: %s", imagePath)
+	if Exists(name, path) {
+		return fmt.Errorf("image doesn't exist: %s", imagePath(name, path))
 	}
 
-	return os.Remove(imagePath)
+	return os.Remove(imagePath(path, name))
+}
+
+func Exists(name, path string) bool {
+	if _, err := os.Stat(imagePath(name, path)); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func imagePath(name, path string) string {
+	return fmt.Sprintf("%s/%s.img", path, name)
 }

--- a/list.go
+++ b/list.go
@@ -18,10 +18,26 @@ List of loopback devices on a system
 `,
 		Run: listRun,
 	}
+
+	listFlags struct {
+		noHeadings bool
+	}
 )
 
+func init() {
+	listCmd.Flags().BoolVar(&listFlags.noHeadings, "no-headings", false, "Don't print headings on top of the list")
+}
+
 func listRun(cmd *cobra.Command, args []string) {
-	list, err := loop.List()
+	var err error
+	var list string
+
+	if listFlags.noHeadings {
+		list, err = loop.ListWithoutHeadings()
+	} else {
+		list, err = loop.List()
+	}
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't list devices: %s\n", err)
 		os.Exit(1)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func Create(name, path string) (string, error) {
+func Attach(name, path string) (string, error) {
 	imagePath := fmt.Sprintf("%s/%s.img", path, name)
 
 	_, err := os.Stat(imagePath)
@@ -32,7 +32,7 @@ func Find(name, path string) (string, error) {
 	return trim(device), nil
 }
 
-func Destroy(device string) error {
+func Detach(device string) error {
 	_, err := losetup([]string{"-d", device})
 	if err != nil {
 		return fmt.Errorf("Can't detach device: %s", err)
@@ -64,16 +64,6 @@ func ListWithoutHeadings() (string, error) {
 	return list(false)
 }
 
-func list(showHeadings bool) (string, error) {
-	args := []string{"--list"}
-
-	if showHeadings == false {
-		args = append(args, "--noheadings")
-	}
-
-	return losetup(args)
-}
-
 func Format(device, fsType string) error {
 	mkfs, err := exec.LookPath(fmt.Sprintf("mkfs.%s", fsType))
 	if err != nil {
@@ -103,6 +93,16 @@ func Mount(device, mountPath string) error {
 	}
 
 	return nil
+}
+
+func list(showHeadings bool) (string, error) {
+	args := []string{"--list"}
+
+	if showHeadings == false {
+		args = append(args, "--noheadings")
+	}
+
+	return losetup(args)
 }
 
 func trim(in string) string {

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -57,7 +57,21 @@ func Unmount(device string) error {
 }
 
 func List() (string, error) {
-	return losetup([]string{"-l"})
+	return list(true)
+}
+
+func ListWithoutHeadings() (string, error) {
+	return list(false)
+}
+
+func list(showHeadings bool) (string, error) {
+	args := []string{"--list"}
+
+	if showHeadings == false {
+		args = append(args, "--noheadings")
+	}
+
+	return losetup(args)
 }
 
 func Format(device, fsType string) error {

--- a/loopback.go
+++ b/loopback.go
@@ -81,6 +81,8 @@ func main() {
 	LoopbackCmd.AddCommand(listCmd)
 	LoopbackCmd.AddCommand(listImagesCmd)
 	LoopbackCmd.AddCommand(destroyCmd)
+	LoopbackCmd.AddCommand(attachCmd)
+	LoopbackCmd.AddCommand(detachCmd)
 
 	LoopbackCmd.Execute()
 }

--- a/mount.go
+++ b/mount.go
@@ -50,7 +50,7 @@ func mountRun(cmd *cobra.Command, args []string) {
 	}
 
 	var device string
-	device, err = loop.Create(mountFlags.name, mountFlags.imagePath)
+	device, err = loop.Attach(mountFlags.name, mountFlags.imagePath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't attach loopback: %s\n", err)
 		os.Exit(1)

--- a/mount.go
+++ b/mount.go
@@ -29,10 +29,15 @@ Attach an image as a loopback and then mount it.
 func init() {
 	mountCmd.Flags().StringVar(&mountFlags.name, "name", "", "Name of the volume")
 	mountCmd.Flags().StringVar(&mountFlags.imagePath, "image-path", "/var/lib/loopback", "Path for the loopback images")
-	mountCmd.Flags().StringVar(&createFlags.mountPath, "mount-path", "", "Path to mount loopback device into")
+	mountCmd.Flags().StringVar(&mountFlags.mountPath, "mount-path", "", "Path to mount loopback device into")
 }
 
 func mountRun(cmd *cobra.Command, args []string) {
+	if mountFlags.name == "" {
+		fmt.Fprintln(os.Stderr, "Image name parameter missing.")
+		os.Exit(1)
+	}
+
 	if mountFlags.mountPath == "" {
 		fmt.Fprintln(os.Stderr, "Mount path parameter missing.")
 		os.Exit(1)

--- a/umount.go
+++ b/umount.go
@@ -43,7 +43,7 @@ func umountRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	err = loop.Destroy(device)
+	err = loop.Detach(device)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't detach loopback: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This will extend the workflow of `loopback` and add the  `attach` and `detach` commands to make it possible to avoid using `mount` and `umount` and keep images.

With this change it becomes possible for users to use existing image files if they exist and make sure they can be used again later making automation in e.g. `fleet` clusters possible.
